### PR TITLE
inql.widgets.propertyeditor: fix for python3

### DIFF
--- a/inql/widgets/propertyeditor.py
+++ b/inql/widgets/propertyeditor.py
@@ -179,4 +179,4 @@ if __name__ == "__main__":
         time.sleep(10)
         pe = PropertyEditor.get_instance(columns=['ciao', 'bao'], data=data, empty=['e1', 'e2'])
         PropertyEditor.get_instance(text='test2', columns=['ciao', 'bao'], data=data, empty=['e1', 'e2'])
-        print pe._data
+        print(pe._data)


### PR DESCRIPTION
add parenthesis to print statement to make python3 happy during
stickytape phase.